### PR TITLE
Smoother, 3-dimensional noise

### DIFF
--- a/common/src/main/java/me/adda/terramath/events/TerraMathEvents.java
+++ b/common/src/main/java/me/adda/terramath/events/TerraMathEvents.java
@@ -9,14 +9,19 @@ import net.minecraft.server.level.ServerLevel;
 
 public class TerraMathEvents {
     public static void init() {
+        LifecycleEvent.SETUP.register(TerraMathEvents::onSetup);
         LifecycleEvent.SERVER_LEVEL_LOAD.register(TerraMathEvents::onLevelLoad);
         LifecycleEvent.SERVER_LEVEL_UNLOAD.register(TerraMathEvents::onLevelUnload);
+    }
+
+    private static void onSetup() {
+        NoiseGenerator.init();
     }
 
     private static void onLevelLoad(ServerLevel level) {
         TerrainData data = level.getDataStorage().get(TerrainData::load, TerrainData.IDENTIFIER.toString());
 
-        NoiseGenerator.init();
+        NoiseGenerator.updateSeed();
 
         if (data != null) {
             data.applyToManagers();

--- a/common/src/main/java/me/adda/terramath/math/NoiseGenerator.java
+++ b/common/src/main/java/me/adda/terramath/math/NoiseGenerator.java
@@ -74,7 +74,7 @@ public class NoiseGenerator {
         double size = default_size;
         double initialSize = size;
 
-        while (size >= 1) {
+        while (size >= 4) {
             value += smoothNoise((x / size), (y / size), (z / size)) * size;
             size /= 2.0;
         }
@@ -112,7 +112,7 @@ public class NoiseGenerator {
         // Offset each coordinate by the seed value
         x += seed;
         y += seed;
-        x += seed;
+        z += seed;
 
         int X = (int) Math.floor(x) & 255; // FIND UNIT CUBE THAT
         int Y = (int) Math.floor(y) & 255; // CONTAINS POINT.

--- a/common/src/main/java/me/adda/terramath/math/NoiseGenerator.java
+++ b/common/src/main/java/me/adda/terramath/math/NoiseGenerator.java
@@ -45,60 +45,13 @@ public class NoiseGenerator {
         seed = SeedUtils.getSeed();
     }
 
-    public static double noise(double x, double y, double z, int size) {
-        double value = 0.0;
-        double initialSize = size;
-
-        while (size >= 1) {
-            value += smoothNoise((x / size), (y / size), (z / size)) * size;
-            size /= 2.0;
-        }
-
-        return value / initialSize;
-    }
-
-    private static boolean setSeed = false;
-
     public static double noise(double x, double y, double z) {
-
-        /*if(!setSeed)
-        {
-            setSeed = true;
-            init();
-        }*/
-
         double value = 0.0;
         double size = default_size;
         double initialSize = size;
 
         for(int o = 0; o < 3; o++) {
             value += smoothNoise((x / size), (y / size), (z / size)) * size;
-            size /= 2.0;
-        }
-
-        return value / initialSize;
-    }
-
-    public double noise(double x, double y) {
-        double value = 0.0;
-        double size = default_size;
-        double initialSize = size;
-
-        while (size >= 1) {
-            value += smoothNoise((x / size), (y / size), (0f / size)) * size;
-            size /= 2.0;
-        }
-
-        return value / initialSize;
-    }
-
-    public double noise(double x) {
-        double value = 0.0;
-        double size = default_size;
-        double initialSize = size;
-
-        while (size >= 1) {
-            value += smoothNoise((x / size), (0f / size), (0f / size)) * size;
             size /= 2.0;
         }
 

--- a/common/src/main/java/me/adda/terramath/math/NoiseGenerator.java
+++ b/common/src/main/java/me/adda/terramath/math/NoiseGenerator.java
@@ -10,9 +10,6 @@ public class NoiseGenerator {
     private static int[] p;
 
     public static void init() {
-
-        seed = SeedUtils.getSeed();
-
         // Initialize the permutation array.
         p = new int[512];
         int[] permutation = new int[]{151, 160, 137, 91, 90, 15, 131, 13, 201,
@@ -44,8 +41,8 @@ public class NoiseGenerator {
 
     }
 
-    public long getSeed() {
-        return seed;
+    public static void updateSeed() {
+        seed = SeedUtils.getSeed();
     }
 
     public static double noise(double x, double y, double z, int size) {
@@ -74,7 +71,7 @@ public class NoiseGenerator {
         double size = default_size;
         double initialSize = size;
 
-        while (size >= 4) {
+        for(int o = 0; o < 3; o++) {
             value += smoothNoise((x / size), (y / size), (z / size)) * size;
             size /= 2.0;
         }

--- a/common/src/main/java/me/adda/terramath/math/ParsedFormula.java
+++ b/common/src/main/java/me/adda/terramath/math/ParsedFormula.java
@@ -154,7 +154,7 @@ public class ParsedFormula {
                 case "sigmoid" -> 1.0 / (1.0 + Math.exp(-args.get(0)));
                 case "clamp" -> Math.min(Math.max(args.get(0), args.get(1)), args.get(2));
 
-                case "noise" -> NoiseGenerator.noise(args.get(0),args.get(1),0);
+                case "noise" -> NoiseGenerator.noise(args.get(0), args.get(1), args.get(2));
                 case "rand" -> new Random().nextDouble(args.get(0));
 
                 default -> throw new FormulaException(FormulaParser.ERROR_UNKNOWN_FUNCTION, name);
@@ -328,8 +328,8 @@ public class ParsedFormula {
 
         private void validateFunctionArguments(String name, List<ExpressionNode> args) {
             int expectedArgs = switch (name) {
-                case "pow", "mod", "max", "min", "beta", "noise" -> 2;
-                case "clamp" -> 3;
+                case "pow", "mod", "max", "min", "beta" -> 2;
+                case "clamp", "noise" -> 3;
                 default -> 1;
             };
 


### PR DESCRIPTION
This PR makes the noise function take 3 parameters as suggested in my comment.

The noise function also uses less octaves because it looked a bit messy when going down to size >= 1.

There's also a small typo correction mentioned in the source gist.

Should unused methods in the NoiseGenerator be removed?

`32 * noise(x,y,z) + 32`

![grafik](https://github.com/user-attachments/assets/280b5ffd-4367-46b6-9094-09485f975e65)
